### PR TITLE
Added .NET 4.7-4.8 and VS 2019 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you have solution with many projects and want to migrate to new version of .N
 
 Features:
 
-* Support .Net Frameworks 2.0-4.7.1
+* Support .Net Frameworks 2.0-4.8
 * Support solution folders 
 
 Available through Tools -> Target Framework Migrator

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you have solution with many projects and want to migrate to new version of .N
 
 Features:
 
-* Support .Net Frameworks 2.0-4.6
+* Support .Net Frameworks 2.0-4.7.1
 * Support solution folders 
 
 Available through Tools -> Target Framework Migrator

--- a/TargetFrameworkMigrator/Frameworks.xml
+++ b/TargetFrameworkMigrator/Frameworks.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Frameworks>
+  <Framework Id="262407" Name=".NETFramework,Version=v4.7.1"/>
   <Framework Id="262151" Name=".NETFramework,Version=v4.7"/>
   <Framework Id="262662" Name=".NETFramework,Version=v4.6.2"/>
   <Framework Id="262406" Name=".NETFramework,Version=v4.6.1"/>

--- a/TargetFrameworkMigrator/Frameworks.xml
+++ b/TargetFrameworkMigrator/Frameworks.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Frameworks>
+  <Framework Id="262409" Name=".NETFramework,Version=v4.8"/>
+  <Framework Id="262408" Name=".NETFramework,Version=v4.7.2"/>
   <Framework Id="262407" Name=".NETFramework,Version=v4.7.1"/>
   <Framework Id="262151" Name=".NETFramework,Version=v4.7"/>
   <Framework Id="262662" Name=".NETFramework,Version=v4.6.2"/>

--- a/TargetFrameworkMigrator/Frameworks.xml
+++ b/TargetFrameworkMigrator/Frameworks.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Frameworks>
-  <Framework Id="262409" Name=".NETFramework,Version=v4.8"/>
-  <Framework Id="262408" Name=".NETFramework,Version=v4.7.2"/>
+  <Framework Id="262663" Name=".NETFramework,Version=v4.8"/>
+  <Framework Id="262152" Name=".NETFramework,Version=v4.7.2"/>
   <Framework Id="262407" Name=".NETFramework,Version=v4.7.1"/>
   <Framework Id="262151" Name=".NETFramework,Version=v4.7"/>
   <Framework Id="262662" Name=".NETFramework,Version=v4.6.2"/>

--- a/TargetFrameworkMigratorVSIX/source.extension.vsixmanifest
+++ b/TargetFrameworkMigratorVSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="TargetFrameworkMigrator..4f7666b9-e62c-46a1-af25-21ab8742ef00" Version="1.6.5" Language="en-US" Publisher="VHQLabs" />
+    <Identity Id="TargetFrameworkMigrator..4f7666b9-e62c-46a1-af25-21ab8742ef00" Version="1.6.6" Language="en-US" Publisher="VHQLabs" />
     <DisplayName>Target Framework Migrator</DisplayName>
     <Description xml:space="preserve">Change all your .Net projects Target Framework at once</Description>
     <Icon>1359311863_stock_update-fields.png</Icon>

--- a/TargetFrameworkMigratorVSIX/source.extension.vsixmanifest
+++ b/TargetFrameworkMigratorVSIX/source.extension.vsixmanifest
@@ -1,24 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="TargetFrameworkMigrator..4f7666b9-e62c-46a1-af25-21ab8742ef00" Version="1.6.6" Language="en-US" Publisher="VHQLabs" />
-    <DisplayName>Target Framework Migrator</DisplayName>
-    <Description xml:space="preserve">Change all your .Net projects Target Framework at once</Description>
-    <Icon>1359311863_stock_update-fields.png</Icon>
-    <PreviewImage>27-01-2013 19-03-27.png</PreviewImage>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,16.0]" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Assets >
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="TargetFrameworkMigrator" Path="|TargetFrameworkMigrator;PkgdefProjectOutputGroup|" />
-  </Assets>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.VSSDK" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio SDK" />
-  </Prerequisites>
+    <Metadata>
+        <Identity Id="TargetFrameworkMigrator..4f7666b9-e62c-46a1-af25-21ab8742ef00" Version="1.6.6" Language="en-US" Publisher="VHQLabs" />
+        <DisplayName>Target Framework Migrator</DisplayName>
+        <Description xml:space="preserve">Change all your .Net projects Target Framework at once</Description>
+        <Icon>1359311863_stock_update-fields.png</Icon>
+        <PreviewImage>27-01-2013 19-03-27.png</PreviewImage>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[11.0,17.0]" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Assets >
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="TargetFrameworkMigrator" Path="|TargetFrameworkMigrator;PkgdefProjectOutputGroup|" />
+    </Assets>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.VSSDK" Version="[16.0.28315.86,17.0)" DisplayName="Visual Studio SDK" />
+    </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This was originally forked off of looselef/TargetFrameworkMigrator

Note that I have no idea what the magic numbers in frameworks.xml mean so I made up the 4.7.2 and 4.8 ones.

I also created a release https://github.com/Ian1971/TargetFrameworkMigrator/releases/tag/1.6.6 with the binary

fixes #58, fixes #56, fixes #49, fixes #38