### PR TITLE
Crash on VS2019 Fix

### DIFF
--- a/Src/TargetFrameworkMigrator/ProjectsUpdateList.cs
+++ b/Src/TargetFrameworkMigrator/ProjectsUpdateList.cs
@@ -32,17 +32,15 @@ namespace VSChangeTargetFrameworkExtension
       set
       {
         var wrapperBindingList = new SortableBindingList<ProjectModel>(value);
-        try
+        if (!InvokeRequired)
         {
           dataGridView1.DataSource = wrapperBindingList;
-          dataGridView1.Refresh();
         }
-        catch (InvalidOperationException)
+        else
         {
           Invoke(new EventHandler(delegate
           {
             dataGridView1.DataSource = wrapperBindingList;
-            dataGridView1.Refresh();
           }));
         }
       }
@@ -81,11 +79,11 @@ namespace VSChangeTargetFrameworkExtension
     {
       set
       {
-        try
+        if (!InvokeRequired)
         {
-          label1.Text = value;
+          label1.Text = value; 
         }
-        catch (InvalidOperationException)
+        else
         {
           Invoke(new EventHandler(delegate
           {


### PR DESCRIPTION
This PR Fixes two things:
1. Crash of Visual Studio 2019 
2. Removes throwing InvalidOperationException which sometimes leads to 1 
#83 